### PR TITLE
Change string "http" to Uri.UriSchemeHttp

### DIFF
--- a/Netling.Core/Performance/HttpHelper.cs
+++ b/Netling.Core/Performance/HttpHelper.cs
@@ -94,7 +94,7 @@ namespace Netling.Core.Performance
 
         public static Stream GetStream(TcpClient client, Uri uri)
         {
-            if (uri.Scheme == "http")
+            if (uri.Scheme == Uri.UriSchemeHttp)
                 return client.GetStream();
             
             var stream = new SslStream(client.GetStream());


### PR DESCRIPTION
Instead of using "http" directly, let's use the appropriate Uri.Scheme
